### PR TITLE
Feature/add fields to report

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,11 @@ data:
 ```go
 []struct {
   Name        string
-  Version     string
+  ShortName   string
   LicenseURL  string
   LicenseName string
+  Version     string
+  License     string
 }
 ```
 
@@ -181,6 +183,7 @@ for licenses considered forbidden.
 ## Usages
 
 ### Global
+
 Typically, specify the Go package that builds your Go binary.
 go-licenses expects the same package argument format as `go build`.  For examples:
 

--- a/report.go
+++ b/report.go
@@ -52,35 +52,6 @@ func init() {
 	rootCmd.AddCommand(reportCmd)
 }
 
-var bsd3clause = `Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-`
-
 type libraryData struct {
 	Name        string
 	ShortName   string
@@ -130,7 +101,7 @@ func reportMain(_ *cobra.Command, args []string) error {
 					url = strings.Replace(url, "github.com", "raw.githubusercontent.com", 1)
 					url = strings.Replace(url, "blob/", "", 1)
 				}
-				if !strings.Contains(url, "opensource.google") {
+				if strings.Contains(url, "github") {
 					resp, err := http.Get(url)
 					if err != nil {
 						klog.Errorf("Error downloading license file from: %s, err: %v", url, err)
@@ -143,7 +114,10 @@ func reportMain(_ *cobra.Command, args []string) error {
 					}
 					libData.License = string(b)
 				} else {
-					libData.License = fmt.Sprintf("<PLACEHOLDER_%s>", libData.LicenseName)
+					placeholder := fmt.Sprintf("<PLACEHOLDER_%s>", libData.LicenseName)
+					klog.Errorf("Could not download license file."+
+						" Go to\n %s \n and replace: %s for lib %s", url, placeholder, libData.ShortName)
+					libData.License = placeholder
 				}
 			} else {
 				klog.Warningf("Error discovering license URL: %s", err)

--- a/report.go
+++ b/report.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -51,6 +52,35 @@ func init() {
 	rootCmd.AddCommand(reportCmd)
 }
 
+var bsd3clause = `Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+`
+
 type libraryData struct {
 	Name        string
 	ShortName   string
@@ -79,10 +109,11 @@ func reportMain(_ *cobra.Command, args []string) error {
 		}
 		libData := libraryData{
 			Name:        lib.Name(),
-			ShortName:   strings.Replace(lib.Name(), "github.com/", "", 1),
+			ShortName:   lib.Name(),
 			Version:     version,
 			LicenseURL:  UNKNOWN,
 			LicenseName: UNKNOWN,
+			License:     UNKNOWN,
 		}
 		if lib.LicensePath != "" {
 			name, _, err := classifier.Identify(lib.LicensePath)
@@ -94,17 +125,26 @@ func reportMain(_ *cobra.Command, args []string) error {
 			url, err := lib.FileURL(context.Background(), lib.LicensePath)
 			if err == nil {
 				libData.LicenseURL = url
-				rawUrl := strings.Replace(url, "github.com", "raw.githubusercontent.com", 1)
-				rawUrl = strings.Replace(rawUrl, "blob/", "", 1)
-				resp, err := http.Get(rawUrl)
-				if err != nil {
-					klog.Errorf("Error downloading license file from: %s, err: %v", rawUrl, err)
+				if strings.Contains(url, "github") {
+					libData.ShortName = strings.Replace(lib.Name(), "github.com/", "", 1)
+					url = strings.Replace(url, "github.com", "raw.githubusercontent.com", 1)
+					url = strings.Replace(url, "blob/", "", 1)
 				}
-				b, err := io.ReadAll(resp.Body)
-				if err != nil {
-					klog.Errorf("Error reading response body: %s, err: %v", rawUrl, err)
+				if !strings.Contains(url, "opensource.google") {
+					resp, err := http.Get(url)
+					if err != nil {
+						klog.Errorf("Error downloading license file from: %s, err: %v", url, err)
+						continue
+					}
+					b, err := io.ReadAll(resp.Body)
+					if err != nil {
+						klog.Errorf("Error reading response body: %s, err: %v", url, err)
+						continue
+					}
+					libData.License = string(b)
+				} else {
+					libData.License = fmt.Sprintf("<PLACEHOLDER_%s>", libData.LicenseName)
 				}
-				libData.License = string(b)
 			} else {
 				klog.Warningf("Error discovering license URL: %s", err)
 			}


### PR DESCRIPTION
# Description

Downloads license from github and adds a placeholder license for other websites. Furthermore, adds a shortname for libs.
This can be used to generate better reports.